### PR TITLE
fix makefile for M1 mac

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -14,9 +14,9 @@ MACHINE_SYS := $(shell uname -m)
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
-	LDFLAGS = -arch x86_64 -bundle -flat_namespace -undefined suppress
+	CFLAGS ?= -O3 -std=c99 -arch $(MACHINE_SYS) -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -arch $(MACHINE_SYS) -finline-functions -Wall
+	LDFLAGS = -arch $(MACHINE_SYS) -bundle -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -I /usr/local/include


### PR DESCRIPTION
Was hard-coded to compile for x86 on mac causing it to break on M1, now sets -arch dynamically 

(same issue as https://github.com/HalloAppInc/enif_protobuf/pull/16)